### PR TITLE
BOM-2247: Upgrade pip-tools

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,6 @@ Django<2.3
 
 # Version 4.0.0 dropped support for Django < 2.0.1
 django-model-utils<4.0.0
+
+# See https://openedx.atlassian.net/browse/BOM-2247 for details.
+pip-tools==5.3.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,9 @@
 #
 #    make upgrade
 #
-click==7.0                # via pip-tools
-pip-tools==4.3.0
-six==1.13.0               # via pip-tools
+click==7.1.2              # via pip-tools
+pip-tools==5.3.0          # via -c requirements/constraints.txt, -r requirements/pip-tools.in
+six==1.15.0               # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip


### PR DESCRIPTION
We are using `pip==20.0.2` in configuration, which is compatible with pip-tools up to version `5.3.0`.
The compatibility chart is available at https://github.com/jazzband/pip-tools/#versions-and-compatibility

See https://openedx.atlassian.net/browse/BOM-2247 for details.